### PR TITLE
ra - create a database table for UCSBDiningCommonMenuItems

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a UCSBDiningCommonsMenuItem.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitem")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+/**
+ * The UCSBDiningCommonsMenuItemRepository is a repository for UCSBDiningCommonsMenuItem entities.
+ */
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> { 
+
+}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -1,0 +1,60 @@
+{ "databaseChangeLog": [
+  {
+      "changeSet": {
+        "id": "UCSBDiningCommonsMenuItem-1",
+        "author": "RubenAG",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "UCSBDININGCOMMONSMENUITEM"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "UCSBDININGCOMMONSMENUITEM_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DINING_COMMONS_CODE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "STATION",
+                    "type": "VARCHAR(255)"
+                  }
+                }]
+              ,
+              "tableName": "UCSBDININGCOMMONSMENUITEM"
+            }
+          }]
+
+      }
+  }
+]}


### PR DESCRIPTION
Closes #8 

In this PR, we add a database table that represents UCSB dining common menu items with the following fields:

```
String diningCommonsCode;
String name;
String station;
```

You can test this by running on local host with 
```
mvn spring-boot:run
```
and looking for the UCSBDININGCOMMONSMENUITEM table on the h2-console

![Screenshot 2025-04-23 010004](https://github.com/user-attachments/assets/cbc46022-9336-4c60-9802-687ca78f4d5a)

You can also test this by running on dokku and connecting to the postgres database with 
```
dokku postgres:connect team01-dev-rubenalvarezgj-db
``` 
and then running \dt

```
ruben513@dokku-09:~$ dokku postgres:connect team01-dev-rubenalvarezgj
 !     Postgres service team01-dev-rubenalvarezgj does not exist
ruben513@dokku-09:~$ dokku postgres:connect team01-dev-rubenalvarezgj-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_rubenalvarezgj_db=# \dt
                   List of relations
 Schema |           Name            | Type  |  Owner
--------+---------------------------+-------+----------
 public | databasechangelog         | table | postgres
 public | databasechangeloglock     | table | postgres
 public | restaurants               | table | postgres
 public | ucsbdates                 | table | postgres
 public | ucsbdiningcommons         | table | postgres
 public | ucsbdiningcommonsmenuitem | table | postgres
 public | users                     | table | postgres
(7 rows)

```