### PR TITLE
ra - add PUT for UCSBDiningCommonsMenuItem

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,86 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a REST controller for UCSBDiningCommonsMenuItem
+ */
+
+ @Tag(name = "UCSBDiningCommonsMenuItem")
+ @RequestMapping("/api/ucsbdiningcommonsmenuitem")
+ @RestController
+ @Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+  
+  @Autowired
+  UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+
+  /**
+   * List all UCSB Dining Commmons Menu Items
+   * 
+   * @return an iterable of UCSBDiningCommonsMenuItem
+   */
+  @Operation(summary= "List all ucsb items")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItem() {
+    Iterable<UCSBDiningCommonsMenuItem> items = ucsbDiningCommonsMenuItemRepository.findAll();
+    return items;
+  }
+
+
+  /**
+    * Create a new item
+    * 
+    * @param diningCommonsCode  the code of the dining common
+    * @param name          the name of the itenm
+    * @param station the station where the item is located
+    * @return the saved item
+    */
+  @Operation(summary= "Create a new item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+        @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+        @Parameter(name="name") @RequestParam String name,
+        @Parameter(name="station") @RequestParam String station)
+        throws JsonProcessingException {
+          
+          UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = new UCSBDiningCommonsMenuItem();
+          ucsbDiningCommonsMenuItem.setDiningCommonsCode(diningCommonsCode);
+          ucsbDiningCommonsMenuItem.setName(name);
+          ucsbDiningCommonsMenuItem.setStation(station);
+  
+          UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+          
+          return savedUcsbDiningCommonsMenuItem;
+        }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -32,22 +32,21 @@ import java.time.LocalDateTime;
  * This is a REST controller for UCSBDiningCommonsMenuItem
  */
 
- @Tag(name = "UCSBDiningCommonsMenuItem")
- @RequestMapping("/api/ucsbdiningcommonsmenuitem")
- @RestController
- @Slf4j
+@Tag(name = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+@RestController
+@Slf4j
 public class UCSBDiningCommonsMenuItemController extends ApiController {
-  
+
   @Autowired
   UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
-
 
   /**
    * List all UCSB Dining Commmons Menu Items
    * 
    * @return an iterable of UCSBDiningCommonsMenuItem
    */
-  @Operation(summary= "List all ucsb items")
+  @Operation(summary = "List all ucsb items")
   @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("/all")
   public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItem() {
@@ -55,32 +54,49 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
     return items;
   }
 
+  /**
+   * Get a single item by id
+   * 
+   * @param id the id of the item
+   * @return a UCSBDiningCommonsMenuItem
+   */
+  @Operation(summary = "Get a single item")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBDiningCommonsMenuItem getById(
+      @Parameter(name = "id") @RequestParam Long id) {
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+    return ucsbDiningCommonsMenuItem;
+  }
 
   /**
-    * Create a new item
-    * 
-    * @param diningCommonsCode  the code of the dining common
-    * @param name          the name of the itenm
-    * @param station the station where the item is located
-    * @return the saved item
-    */
-  @Operation(summary= "Create a new item")
+   * Create a new item
+   * 
+   * @param diningCommonsCode the code of the dining common
+   * @param name              the name of the itenm
+   * @param station           the station where the item is located
+   * @return the saved item
+   */
+  @Operation(summary = "Create a new item")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PostMapping("/post")
   public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
-        @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
-        @Parameter(name="name") @RequestParam String name,
-        @Parameter(name="station") @RequestParam String station)
-        throws JsonProcessingException {
-          
-          UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = new UCSBDiningCommonsMenuItem();
-          ucsbDiningCommonsMenuItem.setDiningCommonsCode(diningCommonsCode);
-          ucsbDiningCommonsMenuItem.setName(name);
-          ucsbDiningCommonsMenuItem.setStation(station);
-  
-          UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
-          
-          return savedUcsbDiningCommonsMenuItem;
-        }
+      @Parameter(name = "diningCommonsCode") @RequestParam String diningCommonsCode,
+      @Parameter(name = "name") @RequestParam String name,
+      @Parameter(name = "station") @RequestParam String station)
+      throws JsonProcessingException {
+
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = new UCSBDiningCommonsMenuItem();
+    ucsbDiningCommonsMenuItem.setDiningCommonsCode(diningCommonsCode);
+    ucsbDiningCommonsMenuItem.setName(name);
+    ucsbDiningCommonsMenuItem.setStation(station);
+
+    UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository
+        .save(ucsbDiningCommonsMenuItem);
+
+    return savedUcsbDiningCommonsMenuItem;
+  }
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -99,4 +99,30 @@ public class UCSBDiningCommonsMenuItemController extends ApiController {
     return savedUcsbDiningCommonsMenuItem;
   }
 
+  /**
+   * Update a single item
+   * 
+   * @param id       id of the item to update
+   * @param incoming the new item
+   * @return the updated UCSBDiningCommonsMenuItem object
+   */
+  @Operation(summary = "Update a single item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
+      @Parameter(name = "id") @RequestParam Long id,
+      @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
+
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+    ucsbDiningCommonsMenuItem.setDiningCommonsCode(incoming.getDiningCommonsCode());
+    ucsbDiningCommonsMenuItem.setName(incoming.getName());
+    ucsbDiningCommonsMenuItem.setStation(incoming.getStation());
+
+    ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+    return ucsbDiningCommonsMenuItem;
+  }
+
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This is a JPA entity that represents a UCSBDiningCommonsMenuItem.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitem")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+/**
+ * The UCSBDiningCommonsMenuItemRepository is a repository for UCSBDiningCommonsMenuItem entities.
+ */
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> { 
+
+}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -1,0 +1,60 @@
+{ "databaseChangeLog": [
+  {
+      "changeSet": {
+        "id": "UCSBDiningCommonsMenuItem-1",
+        "author": "RubenAG",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "UCSBDININGCOMMONSMENUITEM"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "UCSBDININGCOMMONSMENUITEM_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DINING_COMMONS_CODE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "STATION",
+                    "type": "VARCHAR(255)"
+                  }
+                }]
+              ,
+              "tableName": "UCSBDININGCOMMONSMENUITEM"
+            }
+          }]
+
+      }
+  }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -186,4 +186,74 @@ public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase
                 assertEquals(expectedJson, responseString);
         }
 
+        // Tests for PUT
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_ucsbdiningcommonmenuitem() throws Exception {
+                // arrange
+
+                UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItemOrig = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("carillo")
+                                .name("salad")
+                                .station("saladbar")
+                                .build();
+
+                UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItemEdited = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("portola")
+                                .name("sushi")
+                                .station("sushibar")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ucsbDiningCommonsMenuItemEdited);
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItemOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsbdiningcommonsmenuitem?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(ucsbDiningCommonsMenuItemEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+                // arrange
+
+                UCSBDiningCommonsMenuItem ucsbEditedItem = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("pasta")
+                                .station("general")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ucsbEditedItem);
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsbdiningcommonsmenuitem?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDiningCommonsMenuItem with id 67 not found", json.get("message"));
+
+        }
+
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,147 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+  @MockBean
+  UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  @MockBean
+  UserRepository userRepository;
+
+        // Authorization tests for /api/ucsbdiningcommonsmenuitem/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+  
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+  
+        // I commented this out because it test the GET api but using an id, which we have not implemented yet (we've only implemented GET all)
+        // @Test
+        // public void logged_out_users_cannot_get_by_id() throws Exception {
+        //         mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem?id=7"))
+        //                         .andExpect(status().is(403)); // logged out users can't get by id
+        // }
+
+
+        // Authorization tests for /api/ucsbdiningcommmonsmenuitem/post
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsbdiningcommonsmenuitem/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+                
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdiningcommonsmenuitems() throws Exception {
+                UCSBDiningCommonsMenuItem item1 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("carillo")
+                                .name("burrito")
+                                .station("saladbar")
+                                .build();
+
+                UCSBDiningCommonsMenuItem item2 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("portola")
+                                .name("burger")
+                                .station("grill")
+                                .build();
+
+                ArrayList<UCSBDiningCommonsMenuItem> expectedItems = new ArrayList<>();
+                expectedItems.addAll(Arrays.asList(item1, item2));
+
+                when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedItems);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedItems);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_item() throws Exception {
+                // arrange
+
+                UCSBDiningCommonsMenuItem burrito = UCSBDiningCommonsMenuItem.builder()
+                                .name("burrito")
+                                .diningCommonsCode("ortega")
+                                .station("mexicanbar")
+                                .build();
+
+                when(ucsbDiningCommonsMenuItemRepository.save(eq(burrito))).thenReturn(burrito);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/ucsbdiningcommonsmenuitem/post?name=burrito&diningCommonsCode=ortega&station=mexicanbar")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(burrito);
+                String expectedJson = mapper.writeValueAsString(burrito);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+  
+}


### PR DESCRIPTION
Closes #11 

In this PR, we add the PUT operation to the UCSBDiningCommonsMenuItem controller so that we will be able to edit existing items.

![Screenshot 2025-04-24 012613](https://github.com/user-attachments/assets/1259c476-68ed-4f79-a9e5-a2c4dff2dec2)
