### PR TITLE
MB - add GET (show) endpoint for a single record in Articles table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -26,6 +26,23 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Optional;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+
+
+
 
 /**
  * This is a REST controller for Articles
@@ -89,5 +106,26 @@ public class ArticlesController extends ApiController {
         Articles savedArticles = articlesRepository.save(articles);
 
         return savedArticles;
+    }
+
+ /**
+ * Get a single article by id
+ * 
+ * @param id the id of the article
+ * @return the article
+ * @throws EntityNotFoundException if the article is not found
+ */
+
+// …
+
+ @Operation(summary = "Get a single article")
+    @PreAuthorize("hasRole('USER')")
+    @GetMapping("")
+    public Articles getById(@RequestParam Long id) {
+        return articlesRepository.findById(id)
+            .orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                "id " + id + " not found"
+            ));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -118,14 +118,11 @@ public class ArticlesController extends ApiController {
 
 // …
 
- @Operation(summary = "Get a single article")
-    @PreAuthorize("hasRole('USER')")
-    @GetMapping("")
-    public Articles getById(@RequestParam Long id) {
-        return articlesRepository.findById(id)
-            .orElseThrow(() -> new ResponseStatusException(
-                HttpStatus.NOT_FOUND,
-                "id " + id + " not found"
-            ));
-    }
+@Operation(summary = "Get a single article")
+@PreAuthorize("hasRole('USER')")
+@GetMapping("")
+public Articles getById(@RequestParam Long id) {
+    return articlesRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+}
 }

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -9,3 +9,5 @@ app.showSwaggerUILink=true
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always
+server.error.include-message=always
+server.error.include-binding-errors=always


### PR DESCRIPTION
Closes #40

In this PR, we add another endpoint to the Articles controller, one that allows us to get an item by its id., Also throws an error with invalid ID's

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/4ff1c96a-9c76-43ed-9461-79c32bf86a61" />
